### PR TITLE
Escape additional special characters

### DIFF
--- a/scanf.py
+++ b/scanf.py
@@ -106,7 +106,7 @@ def scanf_compile(format, collapseWhitespace=True):
         if not found:
             char = format[i]
             # escape special characters
-            if char in "()[]-.+*?{}<>\\":
+            if char in "^$()[]-.+*?{}<>\\":
                 format_pat += "\\"
             format_pat += char
             i += 1

--- a/scanf.py
+++ b/scanf.py
@@ -106,7 +106,7 @@ def scanf_compile(format, collapseWhitespace=True):
         if not found:
             char = format[i]
             # escape special characters
-            if char in "^$()[]-.+*?{}<>\\":
+            if char in "|^$()[]-.+*?{}<>\\":
                 format_pat += "\\"
             format_pat += char
             i += 1


### PR DESCRIPTION
This fixes #2.

With these changes, the characters `^|$` are also treated as special characters that are escaped when generating the underlying regular expression from a scanf-format.