### PR TITLE
make scanf work with python 2.7

### DIFF
--- a/scanf.py
+++ b/scanf.py
@@ -21,7 +21,10 @@ skip fields.
 """
 import re
 import sys
-from functools import lru_cache
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 __version__ = '1.5'
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     long_description_content_type="text/markdown",
     license = "MIT",
     keywords = "scanf",
+    install_requires=['backports.functools_lru_cache;python_version<"2.9"'],
     platform = "any",
     url = "https://github.com/joshburnett/scanf",
 )


### PR DESCRIPTION
For python 2.7 we use https://pypi.org/project/backports.functools_lru_cache. See #6 

@joshburnett 