### PR TITLE
do not import scanf in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,24 @@
-import scanf
+import re
 from setuptools import setup
 
 with open('README.md') as readme:
     scanf_long_description = readme.read()
 
 
+def get_version(filename='scanf.py'):
+    """ Extract version information from source code """
+    version = '' 
+    with open(filename, 'r') as fp:
+        for line in fp:
+            m = re.search('__version__ .* ''(.*)''', line)
+            if m is not None:
+                version = (m.group(1)).strip('\'')
+                break
+    return version
+
 setup(
     name = "scanf",
-    version = scanf.__version__,
+    version = get_version(),
 
     py_modules=["scanf"],
 


### PR DESCRIPTION
Installing `scanf` in python 2.7 fails because `backports.functools_lru_cache` is not always installed . In the `setup.py` the `backports.functools_lru_cache` is in `install_requires`, but at the top of `setup.py` the `scanf` package is already loaded.

This PR fixes this by parsing the version from the code directly.