### PR TITLE
Integer formats

### DIFF
--- a/scanf.py
+++ b/scanf.py
@@ -45,11 +45,11 @@ scanf_translate = [
         (r"%(\d)c", r"(.{%s})", lambda x:x),
         (r"%\*(\d)c", r"(?:.{%s})", None),
 
-        (r"%(\d)[di]", r"([+-]?\d{%s})", int),
-        (r"%\*(\d)[di]", r"(?:[+-]?\d{%s})", None),
+        (r"%(\d)d", r"([+-]?\d{%s})", int),
+        (r"%\*(\d)d", r"(?:[+-]?\d{%s})", None),
 
-        (r"%[di]", r"([+-]?\d+)", int),
-        (r"%\*[di]", r"(?:[+-]?\d+)", None),
+        (r"%d", r"([+-]?\d+)", int),
+        (r"%\*d", r"(?:[+-]?\d+)", None),
 
         (r"%u", r"(\d+)", int),
         (r"%\*u", r"(?:\d+)", None),
@@ -68,9 +68,12 @@ scanf_translate = [
 
         (r"%b", r"(?:0[bB])?([01]+)", lambda x: int(x, 2)),
         (r"%\*b", r"(?:0[bB])?(?:[01]+)", None),
+
+        (r"%i", r"([+-]?(?:0[xXoObB])?[0-9a-fA-F]+)", lambda x: int(x, 0)),
+        (r"%\*i", r"(?:[+-]?(?:0[xXoObB])?[0-9a-fA-F]+)", None),
         
         (r"%r", r"(.*$)", lambda x: x),
-        (r"%*r", r"(?:.*$)", None),
+        (r"%\*r", r"(?:.*$)", None),
     ]]
 
 

--- a/scanf.py
+++ b/scanf.py
@@ -63,8 +63,14 @@ scanf_translate = [
         (r"%[xX]", r"((?:0[xX])?[\dA-Za-f]+)", lambda x:int(x, 16)),
         (r"%\*[xX]", r"(?:(?:0[xX])?[\dA-Fa-f]+)", None),
 
-        (r"%o", r"(0[0-7]*)", lambda x:int(x, 8)),
-        (r"%\*o", r"(?:0[0-7]*)", None),
+        (r"%o", r"(?:0[oO])?([0-7]+)", lambda x:int(x, 8)),
+        (r"%\*o", r"(?:(?:0[oO])?[0-7]+)", None),
+
+        (r"%b", r"(?:0[bB])?([01]+)", lambda x: int(x, 2)),
+        (r"%\*b", r"(?:0[bB])?(?:[01]+)", None),
+        
+        (r"%r", r"(.*$)", lambda x: x),
+        (r"%*r", r"(?:.*$)", None),
     ]]
 
 

--- a/scanf.py
+++ b/scanf.py
@@ -39,32 +39,32 @@ DEBUG = False
 #   few characters needed to handle the field ommision.
 scanf_translate = [
     (re.compile(_token), _pattern, _cast) for _token, _pattern, _cast in [
-        ("%c", "(.)", lambda x:x),
-        ("%\*c", "(?:.)", None),
+        (r"%c", r"(.)", lambda x:x),
+        (r"%\*c", r"(?:.)", None),
 
-        ("%(\d)c", "(.{%s})", lambda x:x),
-        ("%\*(\d)c", "(?:.{%s})", None),
+        (r"%(\d)c", r"(.{%s})", lambda x:x),
+        (r"%\*(\d)c", r"(?:.{%s})", None),
 
-        ("%(\d)[di]", "([+-]?\d{%s})", int),
-        ("%\*(\d)[di]", "(?:[+-]?\d{%s})", None),
+        (r"%(\d)[di]", r"([+-]?\d{%s})", int),
+        (r"%\*(\d)[di]", r"(?:[+-]?\d{%s})", None),
 
-        ("%[di]", "([+-]?\d+)", int),
-        ("%\*[di]", "(?:[+-]?\d+)", None),
+        (r"%[di]", r"([+-]?\d+)", int),
+        (r"%\*[di]", r"(?:[+-]?\d+)", None),
 
-        ("%u", "(\d+)", int),
-        ("%\*u", "(?:\d+)", None),
+        (r"%u", r"(\d+)", int),
+        (r"%\*u", r"(?:\d+)", None),
 
-        ("%[fgeE]", "([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)", float),
-        ("%\*[fgeE]", "(?:[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)", None),
+        (r"%[fgeE]", r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)", float),
+        (r"%\*[fgeE]", r"(?:[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)", None),
 
-        ("%s", "(\S+)", lambda x:x),
-        ("%\*s", "(?:\S+)", None),
+        (r"%s", r"(\S+)", lambda x:x),
+        (r"%\*s", r"(?:\S+)", None),
 
-        ("%([xX])", "(0%s[\dA-Za-f]+)", lambda x:int(x, 16)),
-        ("%\*([xX])", "(?:0%s[\dA-Za-f]+)", None),
+        (r"%[xX]", r"((?:0[xX])?[\dA-Za-f]+)", lambda x:int(x, 16)),
+        (r"%\*[xX]", r"(?:(?:0[xX])?[\dA-Fa-f]+)", None),
 
-        ("%o", "(0[0-7]*)", lambda x:int(x, 8)),
-        ("%\*o", "(?:0[0-7]*)", None),
+        (r"%o", r"(0[0-7]*)", lambda x:int(x, 8)),
+        (r"%\*o", r"(?:0[0-7]*)", None),
     ]]
 
 
@@ -80,7 +80,7 @@ def scanf_compile(format, collapseWhitespace=True):
     For example:
     >>> format_re, casts = scanf_compile('%s - %d errors, %d warnings')
     >>> print format_re.pattern
-    (\S+) \- ([+-]?\d+) errors, ([+-]?\d+) warnings
+    (\\S+) \\- ([+-]?\\d+) errors, ([+-]?\\d+) warnings
 
     Translated formats are cached for faster reuse
     """
@@ -129,14 +129,11 @@ def scanf(format, s=None, collapseWhitespace=True):
       %o        octal value
       %X, %x    hex value
       %s        string terminated by whitespace
-
     Examples:
     >>> scanf("%s - %d errors, %d warnings", "/usr/sbin/sendmail - 0 errors, 4 warnings")
     ('/usr/sbin/sendmail', 0, 4)
     >>> scanf("%o %x %d", "0123 0x123 123")
     (83, 291, 123)
-
-
     scanf.scanf returns a tuple of found values
     or None if the format does not match.
     """

--- a/scanf_test.py
+++ b/scanf_test.py
@@ -80,9 +80,9 @@ def test_binary():
     
 def test_integer():
     assert scanf_star("%i", "50")[0] == 50
-    #assert scanf_star("%i", "0x50")[0] == 0x50
-    #assert scanf_star("%i", "0o50")[0] == 0o50
-    #assert scanf_star("%i", "0b1100")[0] == 12
+    assert scanf_star("%i", "0x50")[0] == 0x50
+    assert scanf_star("%i", "0o50")[0] == 0o50
+    assert scanf_star("%i", "0b1100")[0] == 12
 
 def test_multiple():
     assert scanf_star("%s %s", "hello, world") == ("hello,", "world")

--- a/scanf_test.py
+++ b/scanf_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+import scanf
+import pytest
+
+def scanf_star(fmt, data, *args):
+    """Wrap a scanf call to also test null conversion"""
+
+    
+    result = scanf.scanf(fmt, data, *args)
+    if result is not None:
+        null_fmt = fmt.replace('%', '%*')
+        assert scanf.scanf(null_fmt, data, *args) == ()
+    return result
+
+
+def test_float():
+    assert scanf_star("%f", "32.1") == (32.1,)
+    assert scanf_star("%f", "+32.1") == (32.1,)
+    assert scanf_star("%f", "+032.1") == (32.1,)
+    assert scanf_star("%f", "+32.10") == (32.1,)
+    assert scanf_star("%e", "32.2abc") == (32.2,)
+    assert scanf_star("%e", "-32.2") == (-32.2,)
+    assert scanf_star("%g", "32") == (32.,)
+    assert scanf_star("%f", ".3") == (0.3,)
+    assert scanf_star("%f", "0.3") == (0.3,)
+
+def test_skip_beginning():
+    """Note, this behavior is different from C stdlib"""
+    assert scanf_star("%e", "abc 321e-1") == (32.1,)
+
+def test_literals():
+    assert scanf_star("is: %d", "The number is: 52") == (52,)
+    assert scanf_star("is: %d", "The number is 52") is None
+    assert scanf_star("is: %d", "The number is: \n 52") == (52,)
+    
+def test_char():
+    assert scanf_star("%c", "abc") == ('a',)
+    assert scanf_star("%3c", "abc") == ('abc',)
+    assert scanf_star("%5c", "abc") is None
+    assert scanf_star("%s", "The first word") == ("The",)
+    assert scanf_star("%s", "Including: punctuation") == ("Including:",)
+    
+def test_decimal():
+    assert scanf_star("%d", "50")[0] == 50
+    assert scanf_star("%d", "050")[0] == 50
+    assert scanf_star("%d", "0x50")[0] == 0
+
+def test_hex():
+    assert scanf_star("%x", "0x50")[0]  == 0x50
+    assert scanf_star("%x", "0X50")[0]  == 0x50
+    assert scanf_star("%X", "0x50")[0]  == 0x50
+    assert scanf_star("%X", "0X50")[0]  == 0x50
+    assert scanf_star("%x", "50")[0]  == 0x50
+    assert scanf_star("%X", "50")[0]  == 0x50
+
+def test_octal():
+    assert scanf_star("%o", "050")[0] == 0o50
+    #assert scanf_star("%o", "0o50")[0] == 0o50
+    #assert scanf_star("%o", "0O50")[0] == 0o50
+
+def test_binary():
+    pass
+    #assert scanf_star("%b", "1100")[0] == 12
+    #assert scanf_star("%b", "0b1100")[0] == 12
+    
+def test_integer():
+    assert scanf_star("%i", "50")[0] == 50
+    #assert scanf_star("%i", "0x50")[0] == 0x50
+    #assert scanf_star("%i", "0o50")[0] == 0o50
+    #assert scanf_star("%i", "0b1100")[0] == 12
+
+def test_multiple():
+    assert scanf_star("%s %s", "hello, world") == ("hello,", "world")
+
+    # Note that this illustrates the different behavior of
+    # regular expressions: it is able to match the literal comma
+    # rather than the preceding %s consuming it.
+    assert scanf_star("%s, %s", "hello, world") == ("hello", "world")
+    
+    assert scanf_star("%d - %d", "52 - 11") == (52, 11)
+    mac =  scanf_star("%X:%X:%X:%X:%X:%X", "04:23:AB:03:ef:01")
+    assert mac == (0x4, 0x23, 0xab, 0x3, 0xef, 0x1)
+    
+@pytest.mark.xfail(reason="Not implemented yet")
+def test_list():
+    assert scanf_star("%[d]", "4 2 2")[0] == [4, 2, 2]
+    

--- a/scanf_test.py
+++ b/scanf_test.py
@@ -7,9 +7,14 @@ def scanf_star(fmt, data, *args):
 
     
     result = scanf.scanf(fmt, data, *args)
-    if result is not None:
-        null_fmt = fmt.replace('%', '%*')
-        assert scanf.scanf(null_fmt, data, *args) == ()
+    if result is None:
+        return result
+    null_fmt = fmt.replace('%', '%*')
+    assert scanf.scanf(null_fmt, data, *args) == ()
+    if "%r" not in fmt:
+        result_w_rest = scanf.scanf(fmt + r"%r", data, *args)
+        rest_only = scanf.scanf(null_fmt + r"%r", data, *args)
+        assert result_w_rest[-1] == rest_only[0]
     return result
 
 
@@ -45,6 +50,11 @@ def test_decimal():
     assert scanf_star("%d", "050")[0] == 50
     assert scanf_star("%d", "0x50")[0] == 0
 
+def test_signed():
+    assert scanf_star("%d", "-42")[0] == -42
+    assert scanf_star("%d", "+42")[0] == +42
+    assert scanf_star("%d %d", "-0 +42") == (0, 42)
+    
 def test_hex():
     assert scanf_star("%x", "0x50")[0]  == 0x50
     assert scanf_star("%x", "0X50")[0]  == 0x50
@@ -55,14 +65,19 @@ def test_hex():
 
 def test_octal():
     assert scanf_star("%o", "050")[0] == 0o50
-    #assert scanf_star("%o", "0o50")[0] == 0o50
-    #assert scanf_star("%o", "0O50")[0] == 0o50
+    assert scanf_star("%o", "777")[0] == 0o777
+    assert scanf_star("%o", "0o50")[0] == 0o50
+    assert scanf_star("%o", "0O50")[0] == 0o50
 
-@pytest.mark.xfail(reason="Not implemented yet")
+def test_rest():
+    n, r = scanf.scanf("%d %r", "99 bottles of beer on the wall")
+    assert n == 99
+    assert r == "bottles of beer on the wall"
+    
 def test_binary():
     assert scanf_star("%b", "1100")[0] == 12
     assert scanf_star("%b", "0b1100")[0] == 12
-
+    
 def test_integer():
     assert scanf_star("%i", "50")[0] == 50
     #assert scanf_star("%i", "0x50")[0] == 0x50

--- a/scanf_test.py
+++ b/scanf_test.py
@@ -32,14 +32,14 @@ def test_literals():
     assert scanf_star("is: %d", "The number is: 52") == (52,)
     assert scanf_star("is: %d", "The number is 52") is None
     assert scanf_star("is: %d", "The number is: \n 52") == (52,)
-    
+
 def test_char():
     assert scanf_star("%c", "abc") == ('a',)
     assert scanf_star("%3c", "abc") == ('abc',)
     assert scanf_star("%5c", "abc") is None
     assert scanf_star("%s", "The first word") == ("The",)
     assert scanf_star("%s", "Including: punctuation") == ("Including:",)
-    
+
 def test_decimal():
     assert scanf_star("%d", "50")[0] == 50
     assert scanf_star("%d", "050")[0] == 50
@@ -58,11 +58,11 @@ def test_octal():
     #assert scanf_star("%o", "0o50")[0] == 0o50
     #assert scanf_star("%o", "0O50")[0] == 0o50
 
+@pytest.mark.xfail(reason="Not implemented yet")
 def test_binary():
-    pass
-    #assert scanf_star("%b", "1100")[0] == 12
-    #assert scanf_star("%b", "0b1100")[0] == 12
-    
+    assert scanf_star("%b", "1100")[0] == 12
+    assert scanf_star("%b", "0b1100")[0] == 12
+
 def test_integer():
     assert scanf_star("%i", "50")[0] == 50
     #assert scanf_star("%i", "0x50")[0] == 0x50
@@ -76,12 +76,9 @@ def test_multiple():
     # regular expressions: it is able to match the literal comma
     # rather than the preceding %s consuming it.
     assert scanf_star("%s, %s", "hello, world") == ("hello", "world")
-    
+
     assert scanf_star("%d - %d", "52 - 11") == (52, 11)
     mac =  scanf_star("%X:%X:%X:%X:%X:%X", "04:23:AB:03:ef:01")
     assert mac == (0x4, 0x23, 0xab, 0x3, 0xef, 0x1)
-    
-@pytest.mark.xfail(reason="Not implemented yet")
-def test_list():
-    assert scanf_star("%[d]", "4 2 2")[0] == [4, 2, 2]
+
     


### PR DESCRIPTION
This follows the test/raw string PR and updates the integer formats

* Add non-standard binary format
* Update decimal, hex, and integer formats to be consistent with C standard
* Change octal formats to be consistent with python 3, using the 0o prefix rather than just a leading zero as in C

Includes tests for these changes